### PR TITLE
Allow modified exifpy to be installed from pip.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,7 +1,9 @@
 ﻿**********
 Change Log
 **********
-
+3.1.0 - 2023-06-06
+    * Added support for FLIR and MicaSense images
+    
 3.0.0 — 2020-xx-xx
     * **BREAKING CHANGE:** Add type hints, which removes Python2 compatibility
     * Update make_string util to clean up bad values (#128) by Étienne Pelletier

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -14,7 +14,7 @@ from .jpeg import find_jpeg_exif
 from .exceptions import InvalidExif, ExifNotFound
 from .xmp import XMP
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 logger = get_logger()
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author="Ianaré Sévi",
     author_email="ianare@gmail.com",
     packages=find_packages(),
+    requires=["rdflib"],
     scripts=["EXIF.py"],
     url="https://github.com/ianare/exif-py",
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ setup(
     author="Ianaré Sévi",
     author_email="ianare@gmail.com",
     packages=find_packages(),
-    install_requires=["rdflib"],
+    install_requires=[
+        'rdflib>=6.3.2'
+        ],
     scripts=["EXIF.py"],
     url="https://github.com/ianare/exif-py",
     license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-import exifread
+# import exifread
 
 readme_file = open("README.rst", "rt").read()
 
@@ -10,7 +10,7 @@ dev_requirements = [
 
 setup(
     name="ExifRead",
-    version=exifread.__version__,
+    version='3.1.0',
     author="Ianaré Sévi",
     author_email="ianare@gmail.com",
     packages=find_packages(),
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/ianare/exif-py",
     license="BSD",
     keywords="exif image metadata photo",
-    description=" ".join(exifread.__doc__.splitlines()).strip(),
+    description="Read Exif metadata from tiff and jpeg files.",
     long_description=readme_file,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author="Ianaré Sévi",
     author_email="ianare@gmail.com",
     packages=find_packages(),
-    requires=["rdflib"],
+    install_requires=["rdflib"],
     scripts=["EXIF.py"],
     url="https://github.com/ianare/exif-py",
     license="BSD",


### PR DESCRIPTION
I modified the setup.py file to allow exifpy to be installed from GitHub directly.

The command would be:

`pip install git+https://github.com/ecohydro/exifpy.git@develop`

This avoids the need to do a local directory install and should make distribution of the package easier. Ultimately, we will want to try and get these changes propagated into the main package. To that end, I also bumped the version to 3.1.0.
